### PR TITLE
Fixes practical details images on mobile

### DIFF
--- a/source/stylesheets/components/_img.scss
+++ b/source/stylesheets/components/_img.scss
@@ -53,6 +53,7 @@ $Imgs: (
   background-size: contain;
   display: flex;
   justify-content: center;
+  overflow-x: hidden;
 
   img {
     height: 500px;


### PR DESCRIPTION
Currently, images are overflowing on mobile, causing a horizontal scroll on the whole page. This PR fixes it by clipping any overflow.
