### PR TITLE
Fix setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 
-if ! hash bundle 2>/dev/null; then
+if ! hash bundle 1>/dev/null; then
   gem install bundler
 fi
 
-if ! hash bower 2>/dev/null; then
-  npm install bower
-fi
-
 (bundle check &>/dev/null) || bundle install
-bower install
 npm install
+$(npm bin)/bower install

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/subvisual/2016.mirrorconf.com"
   },
+  "dependencies": {
+    "bower": "^1.7.9"
+  },
   "devDependencies": {
     "babel-eslint": "^4.1.8",
     "eslint": "^1.10.3",


### PR DESCRIPTION
Why:
- The setup script is checking if bower is globally installed, and
  installing locally if it is not. Afterwards it attempts to use a
  globally installed bower and obviously fails;
- The setup script is assuming that bower will always be globally
  available, if installed, when it could simply use the Node package
  manifest to declare it as dependency, and use the locally installed
  version instead.

This change addresses the need by:
- Adding Bower as a Node dependency;
- Refactoring the setup script to install node dependencies and use the
  locally installed bower.
